### PR TITLE
feat: Customer booking data quality dashboard (#12)

### DIFF
--- a/src/data_quality.py
+++ b/src/data_quality.py
@@ -361,9 +361,7 @@ class BaseDataQualityReport:
         duplicate_count = int(self.checker.check_duplicates())
         return {
             "total_duplicates": duplicate_count,
-            "duplicate_percentage": round(
-                (duplicate_count / total_rows) * 100, 2
-            )
+            "duplicate_percentage": round((duplicate_count / total_rows) * 100, 2)
             if total_rows > 0
             else 0.0,
         }

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -595,8 +595,20 @@ class TestBookingDataQualityReport:
         return pd.DataFrame(
             {
                 "num_passengers": [1, 2, 1, 1, 2],
-                "sales_channel": ["Internet", "Internet", "Mobile", "Internet", "Internet"],
-                "trip_type": ["RoundTrip", "OneWay", "RoundTrip", "OneWay", "RoundTrip"],
+                "sales_channel": [
+                    "Internet",
+                    "Internet",
+                    "Mobile",
+                    "Internet",
+                    "Internet",
+                ],
+                "trip_type": [
+                    "RoundTrip",
+                    "OneWay",
+                    "RoundTrip",
+                    "OneWay",
+                    "RoundTrip",
+                ],
                 "booking_complete": [1, 0, 0, 1, 0],
                 "booking_origin": ["US", "(not set)", "UK", "AU", "US"],
                 "length_of_stay": [5, 3, 7, 2, 5],

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -467,7 +467,7 @@ def display_booking_null_note(report: dict):
     if not_set_count > 0:
         st.subheader("Pseudo-Missing Data")
         st.warning(
-            f'**booking_origin** contains {not_set_count:,} records with value '
+            f"**booking_origin** contains {not_set_count:,} records with value "
             f'"{PSEUDO_MISSING_VALUE}", which may represent missing data.'
         )
 


### PR DESCRIPTION
## Summary
- Auto-detect dataset type (booking vs flight) based on column signatures
- Add `CustomerBookingValidator` with `(not set)` detection in `booking_origin`
- Add `BookingDataQualityReport` with completion rate, duplicates, null analysis, and statistics
- Add booking-specific dashboard display (overview metrics, null analysis with pseudo-missing note)
- Existing flight data dashboard path remains completely unchanged

## Test plan
- [x] `TestDetectDatasetType` — 3 tests for booking, flight, and unknown detection
- [x] `TestCustomerBookingValidator` — 3 tests for `(not set)` detection, clean data, missing column
- [x] `TestBookingDataQualityReport` — 4 tests for report structure, completion rate, not-set count, overview metrics
- [x] All 42 tests pass (31 existing + 11 new), zero regressions

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)