### PR TITLE
feat: Duplicate detection and booking origin cleanup (#17)

### DIFF
--- a/src/data_quality.py
+++ b/src/data_quality.py
@@ -509,6 +509,64 @@ class BookingConsistencyValidator:
         return pd.DataFrame(rows)
 
 
+class BookingDuplicateAndOriginAnalyzer:
+    """Detect duplicate rows and analyze booking_origin data quality"""
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def find_duplicates(self) -> pd.DataFrame:
+        """Return duplicate rows (keeps first occurrence, flags the rest)."""
+        mask = self.df.duplicated(keep="first")
+        return self.df[mask]
+
+    def dedup_preview(self) -> Dict[str, Any]:
+        """Preview what de-duplication would look like."""
+        duplicates = self.find_duplicates()
+        return {
+            "duplicates_count": len(duplicates),
+            "clean_count": len(self.df) - len(duplicates),
+            "duplicate_rows": duplicates,
+        }
+
+    def clean_dataset(self) -> pd.DataFrame:
+        """Return dataset with duplicates removed."""
+        return self.df.drop_duplicates(keep="first")
+
+    def flag_not_set_origins(self) -> pd.DataFrame:
+        """Flag rows where booking_origin is '(not set)'."""
+        if "booking_origin" not in self.df.columns:
+            return pd.DataFrame()
+        mask = self.df["booking_origin"].str.strip() == PSEUDO_MISSING_VALUE
+        return self.df[mask]
+
+    def low_volume_origins(self, min_bookings: int = 5) -> pd.DataFrame:
+        """Return origins with fewer than min_bookings bookings.
+
+        Returns:
+            DataFrame with columns: booking_origin, count
+        """
+        if "booking_origin" not in self.df.columns:
+            return pd.DataFrame(columns=["booking_origin", "count"])
+        counts = self.df["booking_origin"].value_counts().reset_index()
+        counts.columns = ["booking_origin", "count"]
+        return counts[counts["count"] < min_bookings].reset_index(drop=True)
+
+    def origin_quality_summary(self) -> Dict[str, Any]:
+        """Summary of booking_origin data quality."""
+        if "booking_origin" not in self.df.columns:
+            return {
+                "total_origins": 0,
+                "not_set_count": 0,
+                "low_volume_count": 0,
+            }
+        return {
+            "total_origins": self.df["booking_origin"].nunique(),
+            "not_set_count": len(self.flag_not_set_origins()),
+            "low_volume_count": len(self.low_volume_origins()),
+        }
+
+
 class BookingOutlierDetector:
     """Detect outliers in booking numeric fields using thresholds and IQR"""
 

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -20,6 +20,7 @@ from data_quality import (
     BookingCompletionAnalyzer,
     BookingOutlierDetector,
     BookingConsistencyValidator,
+    BookingDuplicateAndOriginAnalyzer,
     detect_dataset_type,
     PSEUDO_MISSING_VALUE,
 )
@@ -841,6 +842,101 @@ def display_booking_consistency(df: pd.DataFrame):
                 st.info(f"Showing first 50 of {len(same_day)} records")
 
 
+def display_duplicate_and_origin_analysis(df: pd.DataFrame):
+    """Display duplicate detection and booking origin cleanup analysis"""
+    st.header("🔁 Duplicate Detection & Origin Cleanup")
+
+    analyzer = BookingDuplicateAndOriginAnalyzer(df)
+    preview = analyzer.dedup_preview()
+    not_set = analyzer.flag_not_set_origins()
+    summary = analyzer.origin_quality_summary()
+
+    # Metric cards
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        dup_pct = (
+            round((preview["duplicates_count"] / len(df)) * 100, 2)
+            if len(df) > 0
+            else 0
+        )
+        st.metric(
+            "Exact Duplicates",
+            f"{preview['duplicates_count']:,}",
+            delta=f"{dup_pct}%" if preview["duplicates_count"] > 0 else None,
+            delta_color="inverse",
+        )
+    with col2:
+        st.metric(
+            "Clean Row Count",
+            f"{preview['clean_count']:,}",
+        )
+    with col3:
+        st.metric(
+            '"(not set)" Origins',
+            f"{len(not_set):,}",
+            delta="Issues found" if len(not_set) > 0 else None,
+            delta_color="inverse",
+        )
+    with col4:
+        low_vol = analyzer.low_volume_origins()
+        st.metric(
+            "Low-Volume Origins (<5)",
+            f"{len(low_vol):,}",
+            delta=f"of {summary['total_origins']} total" if len(low_vol) > 0 else None,
+            delta_color="off",
+        )
+
+    st.markdown("---")
+
+    # Duplicate preview
+    st.subheader("Duplicate Rows Preview")
+    if preview["duplicates_count"] > 0:
+        with st.expander(f"View {preview['duplicates_count']:,} duplicate rows"):
+            st.dataframe(preview["duplicate_rows"].head(50), use_container_width=True)
+            if preview["duplicates_count"] > 50:
+                st.info(
+                    f"Showing first 50 of {preview['duplicates_count']:,} duplicates"
+                )
+    else:
+        st.success("No duplicate rows found!")
+
+    st.markdown("---")
+
+    # Low-volume origins table
+    st.subheader("Low-Volume Booking Origins")
+    if len(low_vol) > 0:
+        fig = px.bar(
+            low_vol.sort_values("count"),
+            x="count",
+            y="booking_origin",
+            orientation="h",
+            title=f"Origins with Fewer Than 5 Bookings ({len(low_vol)} countries)",
+            labels={"count": "Bookings", "booking_origin": "Origin"},
+            color="count",
+            color_continuous_scale="Reds_r",
+        )
+        fig.update_layout(
+            yaxis={"categoryorder": "total ascending"},
+            height=max(300, len(low_vol) * 25),
+        )
+        st.plotly_chart(fig, use_container_width=True)
+    else:
+        st.success("All origins have sufficient booking volume.")
+
+    st.markdown("---")
+
+    # Export cleaned dataset
+    st.subheader("Export Cleaned Dataset")
+    clean = analyzer.clean_dataset()
+    csv_data = clean.to_csv(index=False)
+    st.download_button(
+        label=f"📥 Download De-duplicated Dataset ({len(clean):,} rows)",
+        data=csv_data,
+        file_name="customer_booking_cleaned.csv",
+        mime="text/csv",
+    )
+
+
 def display_download_section(report: dict, report_filename: str):
     """Display download buttons for report exports"""
     import json
@@ -934,6 +1030,9 @@ def main():
             st.markdown("---")
 
             display_booking_consistency(df)
+            st.markdown("---")
+
+            display_duplicate_and_origin_analysis(df)
             st.markdown("---")
 
             display_null_analysis(report)


### PR DESCRIPTION
## Summary
- Added `BookingDuplicateAndOriginAnalyzer` class with duplicate detection, de-duplication preview, `(not set)` origin flagging, low-volume origin detection, and clean dataset export
- Dashboard section with metric cards, duplicate preview expander, low-volume origins bar chart, and CSV export button
- 9 new tests covering all methods, edge cases, empty DataFrames, and missing columns

## Test plan
- [x] 9 new tests in `TestBookingDuplicateAndOriginAnalyzer`
- [x] All 78 tests pass (`python3 -m pytest -v`)
- [x] Code formatted with `black`

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)